### PR TITLE
Close playwright browser if an error occurs

### DIFF
--- a/src/utils/runner.ts
+++ b/src/utils/runner.ts
@@ -104,6 +104,7 @@ export class PlaywrightRunner {
         try {
           await (async () => vm.run(preOpenAction))();
         } catch (e) {
+          await this.teardown();
           throw new Error(`invalid action "${preOpenAction}"`);
         }
       }
@@ -117,6 +118,7 @@ export class PlaywrightRunner {
           await (async () => vm.run(postOpenAction))();
           await this.page.waitForLoadState();
         } catch (e) {
+          await this.teardown();
           throw new Error(`invalid action "${postOpenAction}"`);
         }
       }

--- a/tests/runner.test.ts
+++ b/tests/runner.test.ts
@@ -654,9 +654,7 @@ test("PlaywrightRunner closes the browser after completing the job", async (t) =
     steps: [
       {
         url: `${testAppURL}/`,
-        actions: [
-          "page.waitForSelector('h1')",
-        ],
+        actions: ["page.waitForSelector('h1')"],
       },
     ],
     cookies: [],
@@ -678,10 +676,7 @@ test("PlaywrightRunner closes the browser if an error occurs", async (t) => {
     steps: [
       {
         url: `${testAppURL}/`,
-        actions: [
-          "page.on('invalid')",
-          "page.waitForSelector('h1')",
-        ],
+        actions: ["page.on('invalid')", "page.waitForSelector('h1')"],
       },
     ],
     cookies: [],
@@ -694,7 +689,7 @@ test("PlaywrightRunner closes the browser if an error occurs", async (t) => {
       await runner_1.exec();
       await runner_1.finish();
     },
-    { message: 'invalid action "page.on(\'invalid\')"' },
+    { message: "invalid action \"page.on('invalid')\"" },
   );
 
   t.assert(runner_1.browser === undefined);
@@ -717,7 +712,10 @@ test("PlaywrightRunner closes the browser if an error occurs", async (t) => {
       await runner_2.exec();
       await runner_2.finish();
     },
-    { message: 'invalid action "page.waitForSelector(\'nonexistent\', {timeout: 1000})"' },
+    {
+      message:
+        "invalid action \"page.waitForSelector('nonexistent', {timeout: 1000})\"",
+    },
   );
 
   t.assert(runner_2.browser === undefined);


### PR DESCRIPTION
Current version of Tourist does not call `.teardown()` if a handled error occurs during execution. This is undesirable as it leads to many zombie browser processes.