### PR TITLE
add setExtraHTTPHeaders in preOpen actions

### DIFF
--- a/src/utils/runner.ts
+++ b/src/utils/runner.ts
@@ -110,7 +110,8 @@ export class PlaywrightRunner {
             action.startsWith("page.setExtraHTTPHeaders") ||
             action.startsWith("context.on") ||
             action.startsWith("context.setDefaultTimeout") ||
-            action.startsWith("context.setDefaultNavigationTimeout"),
+            action.startsWith("context.setDefaultNavigationTimeout") ||
+            action.startsWith("context.setExtraHTTPHeaders"),
         );
       }
 

--- a/src/utils/runner.ts
+++ b/src/utils/runner.ts
@@ -107,6 +107,7 @@ export class PlaywrightRunner {
             action.startsWith("page.on") ||
             action.startsWith("page.setDefaultTimeout") ||
             action.startsWith("page.setDefaultNavigationTimeout") ||
+            action.startsWith("page.setExtraHTTPHeaders") ||
             action.startsWith("context.on") ||
             action.startsWith("context.setDefaultTimeout") ||
             action.startsWith("context.setDefaultNavigationTimeout"),

--- a/tests/runner.test.ts
+++ b/tests/runner.test.ts
@@ -142,10 +142,14 @@ test("PlaywrightRunner attaches Extra HTTP Headers using preOpen page.setExtraHT
 
   const runner = new PlaywrightRunner({
     browser: JobBrowser.CHROMIUM,
-    steps: [{ 
-      url: `${testAppURL}/record-req?id=${testID}`,
-      actions: ['page.setExtraHTTPHeaders({"My-Custom-Header": "S0m3-cu570m-v4lu3"})'],
-    }],
+    steps: [
+      {
+        url: `${testAppURL}/record-req?id=${testID}`,
+        actions: [
+          'page.setExtraHTTPHeaders({"My-Custom-Header": "S0m3-cu570m-v4lu3"})',
+        ],
+      },
+    ],
     cookies: [],
     options: [],
   });
@@ -174,10 +178,14 @@ test("PlaywrightRunner attaches Extra HTTP Headers using preOpen context.setExtr
 
   const runner = new PlaywrightRunner({
     browser: JobBrowser.CHROMIUM,
-    steps: [{ 
-      url: `${testAppURL}/record-req?id=${testID}`,
-      actions: ['context.setExtraHTTPHeaders({"My-Custom-Header": "S0m3-cu570m-v4lu3"})'],
-    }],
+    steps: [
+      {
+        url: `${testAppURL}/record-req?id=${testID}`,
+        actions: [
+          'context.setExtraHTTPHeaders({"My-Custom-Header": "S0m3-cu570m-v4lu3"})',
+        ],
+      },
+    ],
     cookies: [],
     options: [],
   });

--- a/tests/runner.test.ts
+++ b/tests/runner.test.ts
@@ -136,6 +136,70 @@ test("PlaywrightRunner attaches cookies with SameSite attribute", async (t) => {
   t.is(headers.cookie, "test=test; test2=test2");
 });
 
+test("PlaywrightRunner attaches Extra HTTP Headers using preOpen page.setExtraHTTPHeaders action", async (t) => {
+  const { testApp, testAppURL } = t.context;
+  const testID = uuid4();
+
+  const runner = new PlaywrightRunner({
+    browser: JobBrowser.CHROMIUM,
+    steps: [{ 
+      url: `${testAppURL}/record-req?id=${testID}`,
+      actions: ['page.setExtraHTTPHeaders({"My-Custom-Header": "S0m3-cu570m-v4lu3"})'],
+    }],
+    cookies: [],
+    options: [],
+  });
+
+  await runner.init();
+  await runner.exec();
+  await runner.finish();
+
+  const inspection = await testApp.inject({
+    method: "GET",
+    url: "/inspect-req",
+    query: {
+      id: testID,
+    },
+  });
+
+  const { headers } = inspection.json();
+  const customHeaderName = "My-Custom-Header".toLowerCase();
+  t.assert(headers.hasOwnProperty(customHeaderName));
+  t.is(headers[customHeaderName], "S0m3-cu570m-v4lu3");
+});
+
+test("PlaywrightRunner attaches Extra HTTP Headers using preOpen context.setExtraHTTPHeaders action", async (t) => {
+  const { testApp, testAppURL } = t.context;
+  const testID = uuid4();
+
+  const runner = new PlaywrightRunner({
+    browser: JobBrowser.CHROMIUM,
+    steps: [{ 
+      url: `${testAppURL}/record-req?id=${testID}`,
+      actions: ['context.setExtraHTTPHeaders({"My-Custom-Header": "S0m3-cu570m-v4lu3"})'],
+    }],
+    cookies: [],
+    options: [],
+  });
+
+  await runner.init();
+  await runner.exec();
+  await runner.finish();
+
+  const inspection = await testApp.inject({
+    method: "GET",
+    url: "/inspect-req",
+    query: {
+      id: testID,
+    },
+  });
+
+  const { headers } = inspection.json();
+  const customHeaderName = "My-Custom-Header".toLowerCase();
+  t.assert(headers.hasOwnProperty(customHeaderName));
+  t.is(headers[customHeaderName], "S0m3-cu570m-v4lu3");
+});
+
 test("PlaywrightRunner can use multiple steps", async (t) => {
   const { testApp, testAppURL } = t.context;
   const testID_1 = uuid4();


### PR DESCRIPTION
Hello,

When pages visited require specific headers, the [`page.setExtraHttpHeaders`](https://playwright.dev/docs/api/class-page#page-set-extra-http-headers) method can be used.

Currently, as `page.setExtraHttpHeaders` is not part of the `preOpen` actions of Tourist, to access the page needing the headers, ones need to create an action that initiates a new page, sets the extra HTTP Headers and re triggers the request (now with the HTTP headers added), which result in all the requests being done in double.

This PR adds the `page.setExtraHttpHeaders` in the `preOpen` actions.